### PR TITLE
added support to MYSQL 8

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1264,9 +1264,11 @@ class Builder
         // then we can associate those values with the column if it was specified
         // otherwise we can just give these values back without a specific key.
         $results = $this->get($columns);
+        
+        $results = array_change_key_case($results, CASE_UPPER);
 
         $values = array_map(function ($row) use ($columns) {
-            return $row[$columns[0]];
+            return $row[strtoupper($columns[0])];
         }, $results);
 
         // If a key was specified and we have results, we will go ahead and combine


### PR DESCRIPTION
I tried use the package db-sync on MYSQL 8 and I got an exception on:
```php
    private function configure()
    {
        $columns = $this->connection
            ->table('information_schema.columns')
            ->where([
                'table_schema' => $this->database,
                'table_name' => $this->table,
            ])->lists('column_name');
        ....
```

MYSQL 8 has UPPERCASE columns in information_schema.

My propose is convert the column name to case insensitve on function lists.